### PR TITLE
Migrate Modof to modern JuMP/MOI

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,472 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.5"
+manifest_format = "2.0"
+project_hash = "6d0dd3092d758148d88117565579dee78851affe"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BenchmarkTools]]
+deps = ["Compat", "JSON", "Logging", "PrecompileTools", "Printf", "Profile", "Statistics", "UUIDs"]
+git-tree-sha1 = "9670d3febc2b6da60a0ae57846ba74670290653f"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "1.8.0"
+
+[[deps.Bzip2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1b96ea4a01afe0ea4090c5c8039690672dd13f2e"
+uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
+version = "1.0.9+0"
+
+[[deps.CodecBzip2]]
+deps = ["Bzip2_jll", "TranscodingStreams"]
+git-tree-sha1 = "84990fa864b7f2b4901901ca12736e45ee79068c"
+uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
+version = "0.8.5"
+
+[[deps.CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.8"
+
+[[deps.CommonSubexpressions]]
+deps = ["MacroTools"]
+git-tree-sha1 = "cda2cfaebb4be89c9084adaca7dd7333369715c5"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.3.1"
+
+[[deps.Compat]]
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.18.1"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.DelimitedFiles]]
+deps = ["Mmap"]
+git-tree-sha1 = "9e2f36d3c96a820c678f2f1f1782582fcf685bae"
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+version = "1.9.1"
+
+[[deps.DiffResults]]
+deps = ["StaticArraysCore"]
+git-tree-sha1 = "782dd5f4561f5d267313f23853baaaa4c52ea621"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "1.1.0"
+
+[[deps.DiffRules]]
+deps = ["IrrationalConstants", "LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "23163d55f885173722d1e4cf0f6110cdbaf7e272"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "1.15.1"
+
+[[deps.Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+version = "1.11.0"
+
+[[deps.DocStringExtensions]]
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.5"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.7.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions"]
+git-tree-sha1 = "cddeab6487248a39dae1a960fff0ac17b2a28888"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "1.3.3"
+
+    [deps.ForwardDiff.extensions]
+    ForwardDiffStaticArraysExt = "StaticArrays"
+
+    [deps.ForwardDiff.weakdeps]
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[deps.GLPK]]
+deps = ["GLPK_jll", "MathOptInterface"]
+git-tree-sha1 = "1d706bd23e5d2d407bfd369499ee6f96afb0c3ad"
+uuid = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
+version = "1.2.1"
+
+[[deps.GLPK_jll]]
+deps = ["Artifacts", "GMP_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "6aa6294ba949ccfc380463bf50ff988b46de5bc7"
+uuid = "e8aa6df9-e6ca-548a-97ff-1f85fc5b8b98"
+version = "5.0.1+1"
+
+[[deps.GMP_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
+version = "6.3.0+2"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "b2d91fe939cae05960e760110b328288867b5758"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.2.6"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.7.1"
+
+[[deps.JSON]]
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "67c6f1f085cb2671c93fe34244c9cccde30f7a26"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "1.5.0"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.JuMP]]
+deps = ["LinearAlgebra", "MacroTools", "MathOptInterface", "MutableArithmetics", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays"]
+git-tree-sha1 = "4091a1338a0e32766b11b9bd3fac247d34200c77"
+uuid = "4076af6c-e467-56ae-b986-b466b2749572"
+version = "1.30.0"
+
+    [deps.JuMP.extensions]
+    JuMPDimensionalDataExt = "DimensionalData"
+
+    [deps.JuMP.weakdeps]
+    DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.15.0+0"
+
+[[deps.LibGit2]]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.0+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.3+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
+
+[[deps.LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "13ca9e2586b89836fd20cccf56e57e2b9ae7f38f"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.29"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.MacroTools]]
+git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.16"
+
+[[deps.Markdown]]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.Match]]
+deps = ["MacroTools", "OrderedCollections"]
+git-tree-sha1 = "58c5c5db26f2f0512facb359991410b7b5982c38"
+uuid = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
+version = "2.4.1"
+
+[[deps.MathOptInterface]]
+deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "ForwardDiff", "JSON", "LinearAlgebra", "MutableArithmetics", "NaNMath", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays", "SpecialFunctions", "Test"]
+git-tree-sha1 = "ce739e3d8a21313ea418772edfc3b7b15a1dfc16"
+uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+version = "1.50.1"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
+
+[[deps.Modof]]
+deps = ["DelimitedFiles", "Distributed", "GLPK", "JuMP", "LinearAlgebra", "Match", "MathOptInterface", "SparseArrays"]
+path = "."
+uuid = "f25fa5c0-d930-461b-ae93-6173de358a6c"
+version = "0.1.0"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2025.11.4"
+
+[[deps.MutableArithmetics]]
+deps = ["LinearAlgebra", "SparseArrays", "Test"]
+git-tree-sha1 = "7c25249fc13a070f5ba433c50e21e22bb33c6fb0"
+uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
+version = "1.7.1"
+
+[[deps.NaNMath]]
+deps = ["OpenLibm_jll"]
+git-tree-sha1 = "9b8215b1ee9e78a293f99797cd31375471b2bcae"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "1.1.3"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.3.0"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.29+0"
+
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.7+0"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.4+0"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1346c9208249809840c91b26703912dff463d335"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.6+0"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "05868e21324cede2207c6f0f466b4bfef6d5e7ee"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.8.1"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.8.3"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.12.1"
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+    [deps.Pkg.weakdeps]
+    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "07a921781cab75691315adc645096ed5e370cb77"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.3"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Profile]]
+deps = ["StyledStrings"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.12.0"
+
+[[deps.SpecialFunctions]]
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "2700b235561b0335d5bef7097a111dc513b8655e"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.7.2"
+
+    [deps.SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+    [deps.SpecialFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.4"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "86f5831495301b2a1387476cb30f86af7ab99194"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.0"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.8.3+2"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.11.3"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.3.1+2"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.15.0+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.64.0+1"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.7.0+0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,27 @@
+name = "Modof"
+uuid = "f25fa5c0-d930-461b-ae93-6173de358a6c"
+version = "0.1.0"
+authors = ["Aritra Pal"]
+
+[deps]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Match = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[compat]
+GLPK = "1"
+JuMP = "1"
+Match = "2"
+MathOptInterface = "1"
+julia = "1.10"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,0 @@
-julia 0.6
-JuMP
-MathProgBase
-GLPK
-GLPKMathProgInterface
-Match

--- a/Readme.md
+++ b/Readme.md
@@ -29,27 +29,22 @@
 	
 ## Dependencies: ##
 
-1. [Julia v0.6.0](https://julialang.org/downloads/)
+1. [Julia v1.10 or newer](https://julialang.org/downloads/) (tested with Julia v1.12)
 
 ## Installation ##
 
-Once, Julia v0.6.0 has been properly installed, the following instructions in a **Julia** terminal will install **Modof.jl** on the local machine:
+Once Julia has been properly installed, the following instructions in a **Julia** terminal will install **Modof.jl** from a local checkout:
 
 ```julia
-Pkg.clone("https://github.com/aritrasep/Modof.jl")
-Pkg.build("Modof")
+import Pkg
+Pkg.develop(path="/path/to/Modof.jl")
 ```
 
-In case `Pkg.build("Modof")` gives you an error on Linux, you may need to install the GMP library headers. For example, on Ubuntu/Debian and similar, give the following command from a terminal:
+To install directly from GitHub, use:
 
-```
-$ sudo apt-get install libgmp-dev
-```
-
-After that, restart the installation of the package with:
-
-```
-Pkg.build("Modof")
+```julia
+import Pkg
+Pkg.add(url="https://github.com/aritrasep/Modof.jl")
 ```
 
 ## Supporting and Citing: ##

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,27 +12,22 @@
 
 ## Dependencies: ##
 
-1. [Julia v0.6.0](https://julialang.org/downloads/)
+1. [Julia v1.10 or newer](https://julialang.org/downloads/) (tested with Julia v1.12)
 
 ## Installation ##
 
-Once, Julia v0.6.0 has been properly installed, the following instructions in a **Julia** terminal will install **Modof.jl** on the local machine:
+Once Julia has been properly installed, the following instructions in a **Julia** terminal will install **Modof.jl** from a local checkout:
 
 ```julia
-Pkg.clone("https://github.com/aritrasep/Modof.jl")
-Pkg.build("Modof")
+import Pkg
+Pkg.develop(path="/path/to/Modof.jl")
 ```
 
-In case `Pkg.build("Modof")` gives you an error on Linux, you may need to install the GMP library headers. For example, on Ubuntu/Debian and similar, give the following command from a terminal:
+To install directly from GitHub, use:
 
-```
-$ sudo apt-get install libgmp-dev
-```
-
-After that, restart the installation of the package with:
-
-```
-Pkg.build("Modof")
+```julia
+import Pkg
+Pkg.add(url="https://github.com/aritrasep/Modof.jl")
 ```
 
 ## Contents: ##

--- a/src/ModoModel.jl
+++ b/src/ModoModel.jl
@@ -3,7 +3,7 @@
 #  This file is part of the julia module for Multi Objective Optimization     #
 #  (c) Copyright 2017 by Aritra Pal                                           #
 #                                                                             #
-# Permission is hereby granted, free of charge, to any person obtaining a     # 
+# Permission is hereby granted, free of charge, to any person obtaining a     #
 # copy of this software and associated documentation files (the "Software"),  #
 # to deal in the Software without restriction, including without limitation   #
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,    #
@@ -32,169 +32,260 @@
 
 mutable struct objectives
     sense::Vector{Symbol}
-    coefficients::Vector{Vector{Float64}}
-end	
-
-function objectives()
-    objectives(Symbol[], Vector{Float64}[])
+    expressions::Vector{Any}
 end
 
-function ModoModel()
-    model = Model(solver=GLPKSolverMIP())
+objectives() = objectives(Symbol[], Any[])
+
+function _modo_objectives(model::JuMP.Model)
+    return get!(model.ext, :objs) do
+        objectives()
+    end
+end
+
+function ModoModel(optimizer=GLPK.Optimizer; kwargs...)
+    model = JuMP.Model(optimizer; kwargs...)
     model.ext[:objs] = objectives()
-    model
+    return model
 end
 
-@inbounds function objective!(model::JuMP.Model, position::Int64, sense::Symbol, obj)
+function _jump_sense(sense)
+    if sense in (:Min, :MIN, :Minimize, JuMP.MIN_SENSE)
+        return JuMP.MIN_SENSE
+    elseif sense in (:Max, :MAX, :Maximize, JuMP.MAX_SENSE)
+        return JuMP.MAX_SENSE
+    end
+    error("Unsupported objective sense $(repr(sense)); expected :Min or :Max.")
+end
+
+function _sense_symbol(sense)
+    jump_sense = _jump_sense(sense)
+    return jump_sense == JuMP.MAX_SENSE ? :Max : :Min
+end
+
+function objective!(model::JuMP.Model, position::Integer, sense, obj)
+    position >= 1 || throw(ArgumentError("objective position must be positive"))
     if position == 1
-        @objective(model, sense, obj)
-    else
-        position -= 1
-        if position > length(model.ext[:objs].sense)
-            for i in length(model.ext[:objs].sense)+1:position
-                push!(model.ext[:objs].sense, :Min)
-                push!(model.ext[:objs].coefficients, zeros(model.numCols))
-            end
-        end
-        model.ext[:objs].sense[position] = sense    
-        expr = QuadExpr(obj)
-        model.ext[:objs].coefficients[position] = zeros(model.numCols)
-        for i in 1:length(expr.aff.vars)
-            model.ext[:objs].coefficients[position][expr.aff.vars[i].col] += expr.aff.coeffs[i]
-        end
+        JuMP.set_objective(model, _jump_sense(sense), obj)
+        return model
     end
+    objs = _modo_objectives(model)
+    index = position - 1
+    while length(objs.sense) < index
+        push!(objs.sense, :Min)
+        push!(objs.expressions, 0.0)
+    end
+    objs.sense[index] = _sense_symbol(sense)
+    objs.expressions[index] = obj
+    return model
 end
 
-@inbounds function read_a_moo_instance_from_a_mathprogbase_model(model::MathProgBase.AbstractMathProgModel, sense::Vector{Symbol})
-    var_types = MathProgBase.getvartype(model)
-    v_lb = MathProgBase.getvarLB(model)
-    v_ub = MathProgBase.getvarUB(model)
-    for i in 1:length(v_lb)
-        if v_lb[i] == 0.0 && v_ub[i] == 1.0 && var_types[i] != :Cont
-            var_types[i] = :Bin
+function _variable_map(vars::Vector{JuMP.VariableRef})
+    return Dict(var => i for (i, var) in enumerate(vars))
+end
+
+function _linear_coefficients(expr, vars::Vector{JuMP.VariableRef}, var_to_index::Dict{JuMP.VariableRef, Int})
+    coefficients = zeros(length(vars))
+    if expr isa Number
+        return coefficients
+    elseif expr isa JuMP.VariableRef
+        coefficients[var_to_index[expr]] = 1.0
+        return coefficients
+    elseif expr isa JuMP.AffExpr
+        for (var, coefficient) in expr.terms
+            coefficients[var_to_index[var]] += Float64(coefficient)
+        end
+        return coefficients
+    end
+    error("Modof only supports linear JuMP objectives and constraints; got $(typeof(expr)).")
+end
+
+function _linear_constant(expr)
+    if expr isa Number || expr isa JuMP.VariableRef
+        return 0.0
+    elseif expr isa JuMP.AffExpr
+        return Float64(JuMP.constant(expr))
+    end
+    error("Modof only supports linear JuMP objectives and constraints; got $(typeof(expr)).")
+end
+
+function _constraint_bounds(set::MOI.LessThan{Float64}, constant::Float64)
+    return -Inf, set.upper - constant
+end
+
+function _constraint_bounds(set::MOI.GreaterThan{Float64}, constant::Float64)
+    return set.lower - constant, Inf
+end
+
+function _constraint_bounds(set::MOI.EqualTo{Float64}, constant::Float64)
+    rhs = set.value - constant
+    return rhs, rhs
+end
+
+function _constraint_bounds(set::MOI.Interval{Float64}, constant::Float64)
+    return set.lower - constant, set.upper - constant
+end
+
+function _append_constraints!(rows, cons_lb, cons_ub, model::JuMP.Model, vars, var_to_index, F, S)
+    for constraint_ref in JuMP.all_constraints(model, F, S)
+        constraint = JuMP.constraint_object(constraint_ref)
+        push!(rows, _linear_coefficients(constraint.func, vars, var_to_index))
+        lower, upper = _constraint_bounds(constraint.set, _linear_constant(constraint.func))
+        push!(cons_lb, lower)
+        push!(cons_ub, upper)
+    end
+    return nothing
+end
+
+function _extract_linear_constraints(model::JuMP.Model, vars, var_to_index)
+    rows = Vector{Vector{Float64}}()
+    cons_lb = Float64[]
+    cons_ub = Float64[]
+    for F in (JuMP.AffExpr, JuMP.VariableRef)
+        for S in (MOI.LessThan{Float64}, MOI.GreaterThan{Float64}, MOI.EqualTo{Float64}, MOI.Interval{Float64})
+            _append_constraints!(rows, cons_lb, cons_ub, model, vars, var_to_index, F, S)
         end
     end
-    A = MathProgBase.getconstrmatrix(model)
-    cons_lb = MathProgBase.getconstrLB(model)
-    cons_lb = cons_lb[1:end-length(sense)+1]
-    cons_ub = MathProgBase.getconstrUB(model)
-    cons_ub = cons_ub[1:end-length(sense)+1]
-    m, n = size(A)
-    c = zeros(length(sense), n)
-    c[1, :] = MathProgBase.getobj(model)
-    c[2:end, :] = A[end-length(sense)+2:end, :]
+    if isempty(rows)
+        A = zeros(0, length(vars))
+    else
+        A = reduce(vcat, transpose.(rows))
+    end
+    return A, cons_lb, cons_ub
+end
+
+function _extract_variable_data(vars::Vector{JuMP.VariableRef})
+    var_types = Symbol[]
+    v_lb = Float64[]
+    v_ub = Float64[]
+    for var in vars
+        if JuMP.is_binary(var)
+            push!(var_types, :Bin)
+            push!(v_lb, 0.0)
+            push!(v_ub, 1.0)
+        else
+            push!(var_types, JuMP.is_integer(var) ? :Int : :Cont)
+            push!(v_lb, JuMP.has_lower_bound(var) ? Float64(JuMP.lower_bound(var)) : -Inf)
+            push!(v_ub, JuMP.has_upper_bound(var) ? Float64(JuMP.upper_bound(var)) : Inf)
+        end
+    end
+    return var_types, v_lb, v_ub
+end
+
+function _objective_coefficients(model::JuMP.Model, vars, var_to_index)
+    if JuMP.objective_sense(model) == JuMP.FEASIBILITY_SENSE
+        return zeros(length(vars)), :Min
+    end
+    return _linear_coefficients(JuMP.objective_function(model), vars, var_to_index),
+        _sense_symbol(JuMP.objective_sense(model))
+end
+
+function _normalize_objective_rows!(c, sense::Vector{Symbol})
     for i in 1:length(sense)
         if sense[i] == :Max
-            c[i, :] = -1.0*c[i, :]
+            c[i, :] = -1.0 * c[i, :]
         end
     end
-    A = A[1:end-length(sense)+1, :]
-    m, n = size(A)
-    for i in 1:m
+    return c
+end
+
+function _normalize_constraint_rows!(A, cons_lb::Vector{Float64}, cons_ub::Vector{Float64})
+    for i in 1:size(A, 1)
         if cons_ub[i] != Inf && cons_lb[i] == -Inf
-            cons_lb[i] = -1.0*cons_ub[i]
+            cons_lb[i] = -1.0 * cons_ub[i]
             cons_ub[i] = Inf
-            A[i, :] = -1.0*A[i, :]
+            A[i, :] = -1.0 * A[i, :]
         end
     end
-    sparsity = length(findin(A, 0.0))/(m*n)
-    if sparsity >= 0.5
-        A = sparse(A)
-    end
-    if !(:Bin in var_types) && !(:Int in var_types)
-        instance = MOLPInstance(v_lb, v_ub, c, A, cons_lb, cons_ub, 1.0e-9)	
-    end
-    if !(:Cont in var_types) && !(:Int in var_types)
-        instance = MOBPInstance(c, A, cons_lb, cons_ub)	
-    end
-    if !(:Cont in var_types)
-        instance = MOIPInstance(v_lb, v_ub, c, A, cons_lb, cons_ub)	
-    end
-    if :Cont in var_types && :Bin in var_types && !(:Int in var_types)
-        instance = MOMBLPInstance(var_types, v_lb, v_ub, c, A, cons_lb, cons_ub, 1.0e-9)	
-    end
-    if :Cont in var_types && :Int in var_types
-        instance = MOMILPInstance(var_types, v_lb, v_ub, c, A, cons_lb, cons_ub, 1.0e-9)	
-    end
-    instance, sense
+    return A, cons_lb, cons_ub
 end
 
-@inbounds function read_a_boo_instance_from_a_mathprogbase_model(model::MathProgBase.AbstractMathProgModel, sense::Vector{Symbol})
-    var_types = MathProgBase.getvartype(model)
-    v_lb = MathProgBase.getvarLB(model)
-    v_ub = MathProgBase.getvarUB(model)
-    for i in 1:length(v_lb)
-        if v_lb[i] == 0.0 && v_ub[i] == 1.0 && var_types[i] != :Cont
-            var_types[i] = :Bin
-        end
+function _maybe_sparse(A)
+    if isempty(A)
+        return sparse(A)
     end
-    A = MathProgBase.getconstrmatrix(model)
-    cons_lb = MathProgBase.getconstrLB(model)
-    cons_lb = cons_lb[1:end-length(sense)+1]
-    cons_ub = MathProgBase.getconstrUB(model)
-    cons_ub = cons_ub[1:end-length(sense)+1]
-    m, n = size(A)
-    c1 = MathProgBase.getobj(model)
-    c2 = vec(A[end, :])
-    if sense[1] == :Max
-        c1 = -1.0*c1
-    end
-    if sense[2] == :Max
-        c2 = -1.0*c2
-    end
-    A = A[1:end-1, :]
-    m, n = size(A)
-    for i in 1:m
-        if cons_ub[i] != Inf && cons_lb[i] == -Inf
-            cons_lb[i] = -1.0*cons_ub[i]
-            cons_ub[i] = Inf
-            A[i, :] = -1.0*A[i, :]
-        end
-    end
-    sparsity = length(findin(A, 0.0))/(m*n)
-    if sparsity >= 0.5
-        A = sparse(A)
-    end
-    if !(:Bin in var_types) && !(:Int in var_types)
-        instance = BOLPInstance(v_lb, v_ub, c1, c2, A, cons_lb, cons_ub, 1.0e-9)	
-    end
-    if !(:Cont in var_types) && !(:Int in var_types)
-        instance = BOBPInstance(c1, c2, A, cons_lb, cons_ub)	
-    end
-    if !(:Cont in var_types)
-        instance = BOIPInstance(v_lb, v_ub, c1, c2, A, cons_lb, cons_ub)	
-    end
-    if :Cont in var_types && :Bin in var_types && !(:Int in var_types)
-        instance = BOMBLPInstance(var_types, v_lb, v_ub, c1, c2, A, cons_lb, cons_ub, 1.0e-9)
-    end
-    if :Cont in var_types && :Int in var_types
-        instance = BOMILPInstance(var_types, v_lb, v_ub, c1, c2, A, cons_lb, cons_ub, 1.0e-9)	
-    end
-    instance, sense
+    sparsity = count(iszero, A) / length(A)
+    return sparsity >= 0.5 ? sparse(A) : A
 end
 
-@inbounds function read_an_instance_from_a_jump_model(model::JuMP.Model)
-    model_ = deepcopy(model)
-    JuMP.build(model_)
-    insert!(model_.ext[:objs].sense, 1, MathProgBase.getsense(model_.internalModel))
-    for i in 1:length(model_.ext[:objs].coefficients)
-        inds = findn(model_.ext[:objs].coefficients[i])
-        MathProgBase.addconstr!(model_.internalModel, inds, model_.ext[:objs].coefficients[i][inds], 0.0, 0.0)
+function _build_instance(var_types, v_lb, v_ub, c, A, cons_lb, cons_ub)
+    has_cont = :Cont in var_types
+    has_bin = :Bin in var_types
+    has_int = :Int in var_types
+    A = _maybe_sparse(A)
+    if size(c, 1) == 2
+        c1 = vec(c[1, :])
+        c2 = vec(c[2, :])
+        if !has_bin && !has_int
+            return BOLPInstance(v_lb, v_ub, c1, c2, A, cons_lb, cons_ub, 1.0e-9)
+        elseif has_bin && !has_cont && !has_int
+            return BOBPInstance(c1, c2, A, cons_lb, cons_ub)
+        elseif !has_cont
+            return BOIPInstance(v_lb, v_ub, c1, c2, A, cons_lb, cons_ub)
+        elseif has_bin && !has_int
+            return BOMBLPInstance(var_types, v_lb, v_ub, c1, c2, A, cons_lb, cons_ub, 1.0e-9)
+        else
+            return BOMILPInstance(var_types, v_lb, v_ub, c1, c2, A, cons_lb, cons_ub, 1.0e-9)
+        end
     end
-    if length(model_.ext[:objs].sense) == 2
-        read_a_boo_instance_from_a_mathprogbase_model(model_.internalModel, model_.ext[:objs].sense)
+    if !has_bin && !has_int
+        return MOLPInstance(v_lb, v_ub, c, A, cons_lb, cons_ub, 1.0e-9)
+    elseif has_bin && !has_cont && !has_int
+        return MOBPInstance(c, A, cons_lb, cons_ub)
+    elseif !has_cont
+        return MOIPInstance(v_lb, v_ub, c, A, cons_lb, cons_ub)
+    elseif has_bin && !has_int
+        return MOMBLPInstance(var_types, v_lb, v_ub, c, A, cons_lb, cons_ub, 1.0e-9)
     else
-        read_a_moo_instance_from_a_mathprogbase_model(model_.internalModel, model_.ext[:objs].sense)
+        return MOMILPInstance(var_types, v_lb, v_ub, c, A, cons_lb, cons_ub, 1.0e-9)
     end
 end
 
-@inbounds function read_an_instance_from_a_lp_or_a_mps_file(filename::String, sense::Vector{Symbol})
-    model = MathProgBase.LinearQuadraticModel(GLPKSolverMIP())
-    MathProgBase.loadproblem!(model, filename)
-    insert!(sense, 1, MathProgBase.getsense(model))
-    if length(sense) == 2
-        read_a_boo_instance_from_a_mathprogbase_model(model, sense)
-    else
-        read_a_moo_instance_from_a_mathprogbase_model(model, sense)
+function _instance_from_jump_data(model::JuMP.Model, c, sense::Vector{Symbol}, A, cons_lb, cons_ub)
+    vars = JuMP.all_variables(model)
+    var_types, v_lb, v_ub = _extract_variable_data(vars)
+    c = _normalize_objective_rows!(copy(c), sense)
+    A, cons_lb, cons_ub = _normalize_constraint_rows!(copy(A), copy(cons_lb), copy(cons_ub))
+    return _build_instance(var_types, v_lb, v_ub, c, A, cons_lb, cons_ub), sense
+end
+
+function read_an_instance_from_a_jump_model(model::JuMP.Model)
+    vars = JuMP.all_variables(model)
+    var_to_index = _variable_map(vars)
+    primary_coefficients, primary_sense = _objective_coefficients(model, vars, var_to_index)
+    objs = _modo_objectives(model)
+    sense = [primary_sense; objs.sense]
+    c = zeros(length(sense), length(vars))
+    c[1, :] = primary_coefficients
+    for i in 1:length(objs.expressions)
+        c[i + 1, :] = _linear_coefficients(objs.expressions[i], vars, var_to_index)
     end
+    A, cons_lb, cons_ub = _extract_linear_constraints(model, vars, var_to_index)
+    return _instance_from_jump_data(model, c, sense, A, cons_lb, cons_ub)
+end
+
+function _read_jump_model_with_constraint_objectives(model::JuMP.Model, sense::Vector{Symbol})
+    vars = JuMP.all_variables(model)
+    var_to_index = _variable_map(vars)
+    primary_coefficients, _ = _objective_coefficients(model, vars, var_to_index)
+    A, cons_lb, cons_ub = _extract_linear_constraints(model, vars, var_to_index)
+    length(sense) >= 1 || throw(ArgumentError("sense must contain at least the primary objective sense"))
+    tail_objectives = length(sense) - 1
+    tail_objectives <= size(A, 1) || throw(ArgumentError("not enough trailing constraints to read as additional objectives"))
+    c = zeros(length(sense), length(vars))
+    c[1, :] = primary_coefficients
+    if tail_objectives > 0
+        first_tail = size(A, 1) - tail_objectives + 1
+        c[2:end, :] = A[first_tail:end, :]
+        A = A[1:first_tail-1, :]
+        cons_lb = cons_lb[1:first_tail-1]
+        cons_ub = cons_ub[1:first_tail-1]
+    end
+    return _instance_from_jump_data(model, c, copy(sense), A, cons_lb, cons_ub)
+end
+
+function read_an_instance_from_a_lp_or_a_mps_file(filename::String, sense::Vector{Symbol}=Symbol[])
+    model = JuMP.read_from_file(filename)
+    all_senses = [_sense_symbol(JuMP.objective_sense(model)); sense]
+    return _read_jump_model_with_constraint_objectives(model, all_senses)
 end

--- a/src/ModoModel.jl
+++ b/src/ModoModel.jl
@@ -137,11 +137,11 @@ function _append_constraints!(rows, cons_lb, cons_ub, model::JuMP.Model, vars, v
     return nothing
 end
 
-function _extract_linear_constraints(model::JuMP.Model, vars, var_to_index)
+function _extract_linear_constraints(model::JuMP.Model, vars, var_to_index, function_types)
     rows = Vector{Vector{Float64}}()
     cons_lb = Float64[]
     cons_ub = Float64[]
-    for F in (JuMP.AffExpr, JuMP.VariableRef)
+    for F in function_types
         for S in (MOI.LessThan{Float64}, MOI.GreaterThan{Float64}, MOI.EqualTo{Float64}, MOI.Interval{Float64})
             _append_constraints!(rows, cons_lb, cons_ub, model, vars, var_to_index, F, S)
         end
@@ -153,6 +153,9 @@ function _extract_linear_constraints(model::JuMP.Model, vars, var_to_index)
     end
     return A, cons_lb, cons_ub
 end
+
+_extract_linear_constraints(model::JuMP.Model, vars, var_to_index) =
+    _extract_linear_constraints(model, vars, var_to_index, (JuMP.AffExpr, JuMP.VariableRef))
 
 function _extract_variable_data(vars::Vector{JuMP.VariableRef})
     var_types = Symbol[]
@@ -268,19 +271,25 @@ function _read_jump_model_with_constraint_objectives(model::JuMP.Model, sense::V
     vars = JuMP.all_variables(model)
     var_to_index = _variable_map(vars)
     primary_coefficients, _ = _objective_coefficients(model, vars, var_to_index)
-    A, cons_lb, cons_ub = _extract_linear_constraints(model, vars, var_to_index)
+    A_aff, cons_lb_aff, cons_ub_aff =
+        _extract_linear_constraints(model, vars, var_to_index, (JuMP.AffExpr,))
+    A_var, cons_lb_var, cons_ub_var =
+        _extract_linear_constraints(model, vars, var_to_index, (JuMP.VariableRef,))
     length(sense) >= 1 || throw(ArgumentError("sense must contain at least the primary objective sense"))
     tail_objectives = length(sense) - 1
-    tail_objectives <= size(A, 1) || throw(ArgumentError("not enough trailing constraints to read as additional objectives"))
+    tail_objectives <= size(A_aff, 1) || throw(ArgumentError("not enough trailing affine constraints to read as additional objectives"))
     c = zeros(length(sense), length(vars))
     c[1, :] = primary_coefficients
     if tail_objectives > 0
-        first_tail = size(A, 1) - tail_objectives + 1
-        c[2:end, :] = A[first_tail:end, :]
-        A = A[1:first_tail-1, :]
-        cons_lb = cons_lb[1:first_tail-1]
-        cons_ub = cons_ub[1:first_tail-1]
+        first_tail = size(A_aff, 1) - tail_objectives + 1
+        c[2:end, :] = A_aff[first_tail:end, :]
+        A_aff = A_aff[1:first_tail-1, :]
+        cons_lb_aff = cons_lb_aff[1:first_tail-1]
+        cons_ub_aff = cons_ub_aff[1:first_tail-1]
     end
+    A = vcat(A_aff, A_var)
+    cons_lb = vcat(cons_lb_aff, cons_lb_var)
+    cons_ub = vcat(cons_ub_aff, cons_ub_var)
     return _instance_from_jump_data(model, c, copy(sense), A, cons_lb, cons_ub)
 end
 

--- a/src/Modof.jl
+++ b/src/Modof.jl
@@ -28,7 +28,21 @@
 
 module Modof
 
-using JuMP, MathProgBase, GLPKMathProgInterface, Match
+using DelimitedFiles
+using Distributed
+using GLPK
+using JuMP
+using LinearAlgebra
+using Match
+using MathOptInterface
+using SparseArrays
+
+const MOI = MathOptInterface
+
+findin(collection, values) = findall(x -> x in values, collection)
+findin(collection, value::Number) = findall(==(value), collection)
+findn(collection) = findall(!iszero, collection)
+sortrows(values::AbstractMatrix) = values[sortperm([Tuple(row) for row in eachrow(values)]), :]
 
 include("ModoModel.jl")
 include("Types.jl")
@@ -42,7 +56,7 @@ export BOOInstance, BOPInstance, BOMInstance, BOLPInstance, BOBPInstance, BOIPIn
 export MOOSolution, MOPSolution, BOOSolution, BOPSolution, BOMSolution
 export OOESInstance, OOESSolution
 
-export ModoModel, objective!, read_an_instance_from_a_jump_model, read_an_instance_from_a_lp_or_a_mps_file, read_a_boo_instance_from_a_mathprogbase_model, read_a_moo_instance_from_a_mathprogbase_model
+export ModoModel, objective!, read_an_instance_from_a_jump_model, read_an_instance_from_a_lp_or_a_mps_file
 export lprelaxation, convert_ip_into_bp, convert_bp_sol_into_ip_sol
 export wrap_sols_into_array, compute_objective_function_value!, check_feasibility
 export check_dominance, select_non_dom_sols, select_unique_sols, sort_non_dom_sols, select_and_sort_non_dom_sols, write_nondominated_frontier, write_nondominated_sols, normalize_frontier, compute_ideal_point, compute_closest_point_to_the_ideal_point, compute_nadir_point, compute_farthest_point_to_the_nadir_point

--- a/src/NSGA_II.jl
+++ b/src/NSGA_II.jl
@@ -150,7 +150,7 @@ end
             coeffs = Float64[]
             tmp = split(lines_in_file[i])
             for j in 2+m+1:2+m+n
-                push!(coeffs, float(tmp[j]))
+                push!(coeffs, parse(Float64, tmp[j]))
             end
             tmp2 = BOPSolution(vars=coeffs)
             compute_objective_function_value!(tmp2, instance)

--- a/src/Type_Conversion.jl
+++ b/src/Type_Conversion.jl
@@ -148,9 +148,10 @@ function convert_ip_into_bp(instance::Union{BOIPInstance, BOMILPInstance}, ub::F
             if typeof(instance) == BOMILPInstance && instance.var_types[i] == :Cont
                 continue
             end    
-            num = @match instance.v_ub[i] begin
-                Inf => ceil(Int64, log(ub + 1.0) / log(2.0))
-                _ => ceil(Int64, log(instance.v_ub[i] + 1.0) / log(2.0))
+            num = if isinf(instance.v_ub[i])
+                ceil(Int64, log(ub + 1.0) / log(2.0))
+            else
+                ceil(Int64, log(instance.v_ub[i] + 1.0) / log(2.0))
             end
             push!(pos, [current_pos:(current_pos + num - 1)...])
             tmp1 = instance.c1[i]
@@ -209,9 +210,10 @@ function convert_ip_into_bp(instance::Union{MOIPInstance, MOMILPInstance}, ub::F
             if typeof(instance) == MOMILPInstance && instance.var_types[i] == :Cont
                 continue
             end    
-            num = @match instance.v_ub[i] begin
-                Inf => ceil(Int64, log(ub + 1.0) / log(2.0))
-                _ => ceil(Int64, log(instance.v_ub[i] + 1.0) / log(2.0))
+            num = if isinf(instance.v_ub[i])
+                ceil(Int64, log(ub + 1.0) / log(2.0))
+            else
+                ceil(Int64, log(instance.v_ub[i] + 1.0) / log(2.0))
             end
             push!(pos, [current_pos:(current_pos + num - 1)...])
             tmp1 = instance.c[:, i]

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -56,9 +56,9 @@ end
 
 function MOIPInstance(sparse::Bool=true)
     if sparse
-        return MOIPInstance(Float64[], Float64[], Array{Float64}(1, 1), spzeros(1,1), Float64[], Float64[])
+        return MOIPInstance(Float64[], Float64[], Array{Float64}(undef, 1, 1), spzeros(1,1), Float64[], Float64[])
     else
-        return MOIPInstance(Float64[], Float64[], Array{Float64}(1, 1), Array{Float64}(1, 1), Float64[], Float64[])
+        return MOIPInstance(Float64[], Float64[], Array{Float64}(undef, 1, 1), Array{Float64}(undef, 1, 1), Float64[], Float64[])
     end
 end
 
@@ -80,9 +80,9 @@ end
 
 function MOBPInstance(sparse::Bool=true)
     if sparse
-        return MOBPInstance(Array{Float64}(1, 1), spzeros(1,1), Float64[], Float64[])
+        return MOBPInstance(Array{Float64}(undef, 1, 1), spzeros(1,1), Float64[], Float64[])
     else
-        return MOBPInstance(Array{Float64}(1, 1), Array{Float64}(1, 1), Float64[], Float64[])
+        return MOBPInstance(Array{Float64}(undef, 1, 1), Array{Float64}(undef, 1, 1), Float64[], Float64[])
     end
 end
 
@@ -107,9 +107,9 @@ end
 
 function MOLPInstance(sparse::Bool=true)
     if sparse
-        return MOLPInstance(Float64[], Float64[], Array{Float64}(1, 1), spzeros(1,1), Float64[], Float64[], 1.0e-9)
+        return MOLPInstance(Float64[], Float64[], Array{Float64}(undef, 1, 1), spzeros(1,1), Float64[], Float64[], 1.0e-9)
     else
-        return MOLPInstance(Float64[], Float64[], Array{Float64}(1, 1), Array{Float64}(1, 1), Float64[], Float64[], 1.0e-9)
+        return MOLPInstance(Float64[], Float64[], Array{Float64}(undef, 1, 1), Array{Float64}(undef, 1, 1), Float64[], Float64[], 1.0e-9)
     end
 end
 
@@ -135,9 +135,9 @@ end
 
 function MOMILPInstance(sparse::Bool=true)
     if sparse
-        return MOMILPInstance(Symbol[], Float64[], Float64[], Array{Float64}(1, 1), spzeros(1,1), Float64[], Float64[], 1.0e-9)
+        return MOMILPInstance(Symbol[], Float64[], Float64[], Array{Float64}(undef, 1, 1), spzeros(1,1), Float64[], Float64[], 1.0e-9)
     else
-        return MOMILPInstance(Symbol[], Float64[], Float64[], Array{Float64}(1, 1), Array{Float64}(1, 1), Float64[], Float64[], 1.0e-9)
+        return MOMILPInstance(Symbol[], Float64[], Float64[], Array{Float64}(undef, 1, 1), Array{Float64}(undef, 1, 1), Float64[], Float64[], 1.0e-9)
     end
 end
 
@@ -163,9 +163,9 @@ end
 
 function MOMBLPInstance(sparse::Bool=true)
     if sparse
-        return MOMBLPInstance(Symbol[], Float64[], Float64[], Array{Float64}(1, 1), spzeros(1,1), Float64[], Float64[], 1.0e-9)
+        return MOMBLPInstance(Symbol[], Float64[], Float64[], Array{Float64}(undef, 1, 1), spzeros(1,1), Float64[], Float64[], 1.0e-9)
     else
-        return MOMBLPInstance(Symbol[], Float64[], Float64[], Array{Float64}(1, 1), Array{Float64}(1, 1), Float64[], Float64[], 1.0e-9)
+        return MOMBLPInstance(Symbol[], Float64[], Float64[], Array{Float64}(undef, 1, 1), Array{Float64}(undef, 1, 1), Float64[], Float64[], 1.0e-9)
     end
 end
 
@@ -200,7 +200,7 @@ function BOIPInstance(sparse::Bool=true)
     if sparse
         return BOIPInstance(Float64[], Float64[], Float64[], Float64[], spzeros(1,1), Float64[], Float64[])
     else
-        return BOIPInstance(Float64[], Float64[], Float64[], Float64[], Array{Float64}(1, 1), Float64[], Float64[])
+        return BOIPInstance(Float64[], Float64[], Float64[], Float64[], Array{Float64}(undef, 1, 1), Float64[], Float64[])
     end
 end
 
@@ -225,7 +225,7 @@ function BOBPInstance(sparse::Bool=true)
     if sparse
         return BOBPInstance(Float64[], Float64[], spzeros(1,1), Float64[], Float64[])
     else
-        return BOBPInstance(Float64[], Float64[], Array{Float64}(1, 1), Float64[], Float64[])
+        return BOBPInstance(Float64[], Float64[], Array{Float64}(undef, 1, 1), Float64[], Float64[])
     end
 end
 
@@ -253,7 +253,7 @@ function BOLPInstance(sparse::Bool=true)
     if sparse
         return BOLPInstance(Float64[], Float64[], Float64[], Float64[], spzeros(1,1), Float64[], Float64[], 1.0e-9)
     else
-        return BOLPInstance(Float64[], Float64[], Float64[], Float64[], Array{Float64}(1, 1), Float64[], Float64[], 1.0e-9)
+        return BOLPInstance(Float64[], Float64[], Float64[], Float64[], Array{Float64}(undef, 1, 1), Float64[], Float64[], 1.0e-9)
     end
 end
 
@@ -282,7 +282,7 @@ function BOMILPInstance(sparse::Bool=true)
     if sparse
         return BOMILPInstance(Symbol[], Float64[], Float64[], Float64[], Float64[], spzeros(1,1), Float64[], Float64[], 1.0e-9)
     else
-        return BOMILPInstance(Symbol[], Float64[], Float64[], Float64[], Float64[], Array{Float64}(1, 1), Float64[], Float64[], 1.0e-9)
+        return BOMILPInstance(Symbol[], Float64[], Float64[], Float64[], Float64[], Array{Float64}(undef, 1, 1), Float64[], Float64[], 1.0e-9)
     end
 end
 
@@ -311,7 +311,7 @@ function BOMBLPInstance(sparse::Bool=true)
     if sparse
         return BOMBLPInstance(Symbol[], Float64[], Float64[], Float64[], Float64[], spzeros(1,1), Float64[], Float64[], 1.0e-9)
     else
-        return BOMBLPInstance(Symbol[], Float64[], Float64[], Float64[], Float64[], Array{Float64}(1, 1), Float64[], Float64[], 1.0e-9)
+        return BOMBLPInstance(Symbol[], Float64[], Float64[], Float64[], Float64[], Array{Float64}(undef, 1, 1), Float64[], Float64[], 1.0e-9)
     end
 end
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -65,7 +65,7 @@ end
 
  Compute objective function values of a `MOOSolution` of a Multi Objective Optimization Instance
 """
-function compute_objective_function_value!{T<:MOOInstance, S<:MOOSolution}(solution::S, instance::T)
+function compute_objective_function_value!(solution::S, instance::T) where {T<:MOOInstance, S<:MOOSolution}
     @inbounds for i in 1:size(instance.c)[1]
         if length(solution.obj_vals) >= i
             solution.obj_vals[i] = sum(instance.c[i, :] .* solution.vars)
@@ -80,7 +80,7 @@ end
     
  Compute objective function values of a `vector{MOOSolution}` of a Multi Objective Optimization Instance
 """
-function compute_objective_function_value!{T<:MOOInstance, S<:MOOSolution}(solutions::Vector{S}, instance::T)
+function compute_objective_function_value!(solutions::Vector{S}, instance::T) where {T<:MOOInstance, S<:MOOSolution}
     @inbounds for i in 1:length(solutions)
         compute_objective_function_value!(solutions[i], instance)
     end
@@ -91,7 +91,7 @@ end
 
  Compute objective function values of a `BOOSolution` of a Bi Objective Optimization Instance
 """
-function compute_objective_function_value!{T<:BOOInstance, S<:BOOSolution}(solution::S, instance::T)
+function compute_objective_function_value!(solution::S, instance::T) where {T<:BOOInstance, S<:BOOSolution}
     solution.obj_val1, solution.obj_val2 = sum(instance.c1 .* solution.vars), sum(instance.c2 .* solution.vars)
 end
 
@@ -100,7 +100,7 @@ end
 
  Compute objective function values of a `vector{BOOSolution}` of a Bi Objective Optimization Instance
 """
-function compute_objective_function_value!{T<:BOOInstance, S<:BOOSolution}(solutions::Vector{S}, instance::T)
+function compute_objective_function_value!(solutions::Vector{S}, instance::T) where {T<:BOOInstance, S<:BOOSolution}
     @inbounds for i in 1:length(solutions)
         compute_objective_function_value!(solutions[i], instance)
     end
@@ -197,7 +197,7 @@ end
     
  Checks whether points `point1` and `point2` dominate one another. 
 """
-function check_dominance{T<:Number}(point1::Vector{T}, point2::Vector{T})
+function check_dominance(point1::Vector{T}, point2::Vector{T}) where {T<:Number}
     if point1 == point2
         return (false, true)
     end
@@ -221,7 +221,7 @@ end
 
  Select nondominated points for both Biobjective and Multiobjective Programs. 
 """
-function select_non_dom_sols{T<:Number}(solutions::Array{T,2})
+function select_non_dom_sols(solutions::Array{T,2}) where {T<:Number}
     dom_inds = fill(false, size(solutions)[1])
     @inbounds for i in 1:size(solutions)[1]
         if dom_inds[i]
@@ -297,8 +297,8 @@ end
     
  Select unique nondominated points for both Biobjective and Multiobjective Programs. 
 """
-function select_unique_sols{T<:Number}(solutions::Array{T, 2})
-    unique(solutions, 1)
+function select_unique_sols(solutions::Array{T, 2}) where {T<:Number}
+    unique(solutions; dims=1)
 end
 
 """
@@ -354,7 +354,7 @@ end
     
  Sort nondominated `solutions` for both Biobjective and Multiobjective Programs based on `index` objective. 
 """
-function sort_non_dom_sols{T<:Number}(solutions::Array{T,2}, index::Int64=1)
+function sort_non_dom_sols(solutions::Array{T,2}, index::Int64=1) where {T<:Number}
     if index == 1
         return sortrows(solutions)
     else
@@ -418,7 +418,7 @@ end
     
  Select and Sort nondominated `solutions` for both Biobjective and Multiobjective Programs. 
 """
-function select_and_sort_non_dom_sols{T<:Number}(solutions::Array{T,2}, index::Int64=1)
+function select_and_sort_non_dom_sols(solutions::Array{T,2}, index::Int64=1) where {T<:Number}
     sort_non_dom_sols(select_non_dom_sols(solutions), index)
 end
 
@@ -485,7 +485,7 @@ end
  Write nondominated solutions of a `Vector{BOPSolution}` or a `Vector{MOPSolution}` and save it to `filename`.
 """
 function write_nondominated_sols(non_dom_sols::Union{Vector{MOPSolution}, Vector{BOPSolution}}, filename::String)
-    data = Array{Float64, 2}(length(non_dom_sols), length(non_dom_sols[1].vars))
+    data = Array{Float64, 2}(undef, length(non_dom_sols), length(non_dom_sols[1].vars))
     @inbounds for i in 1:length(non_dom_sols)
         data[i, :] = non_dom_sols[i].vars
     end
@@ -496,7 +496,7 @@ end
 # Normalizing a Frontier                                            #
 #####################################################################
 
-@inbounds function normalize_frontier{T<:Number}(non_dom_sols::Array{T, 2}, true_non_dom_sols::Array{T, 2})
+@inbounds function normalize_frontier(non_dom_sols::Array{T, 2}, true_non_dom_sols::Array{T, 2}) where {T<:Number}
     tmp = copy(non_dom_sols)
     num_i = [ minimum(true_non_dom_sols[:, i]) for i in 1:size(tmp)[2] ]
     den_i = [ maximum(true_non_dom_sols[:, i]) - minimum(true_non_dom_sols[:, i]) for i in 1:size(tmp)[2] ]
@@ -515,7 +515,7 @@ end
     
  Returns the `Ideal Point` of the nondominated frontier `non_dom_sols`.
 """
-function compute_ideal_point{T<:Number}(non_dom_sols::Array{T, 2})
+function compute_ideal_point(non_dom_sols::Array{T, 2}) where {T<:Number}
     [ minimum(non_dom_sols[:, i]) for i in 1:size(non_dom_sols)[2] ]
 end
 
@@ -538,7 +538,7 @@ end
 
  Returns the closest point in the nondominated frontier `non_dom_sols` from its Ideal Point `ideal_point`.
 """
-function compute_closest_point_to_the_ideal_point{T<:Number}(non_dom_sols::Array{T, 2}, ideal_point::Vector{T}, return_pos::Bool=false)
+function compute_closest_point_to_the_ideal_point(non_dom_sols::Array{T, 2}, ideal_point::Vector{T}, return_pos::Bool=false) where {T<:Number}
     best_pt_dist = Inf
     best_pt = Float64[]
     best_pt_pos = 0
@@ -566,7 +566,7 @@ end
 
  Returns the closest point in the nondominated frontier `non_dom_sols` from its Ideal Point `ideal_point`.
 """
-function compute_closest_point_to_the_ideal_point{T<:Number}(non_dom_sols::Union{Vector{MOPSolution}, Vector{BOPSolution}}, ideal_point::Vector{T})
+function compute_closest_point_to_the_ideal_point(non_dom_sols::Union{Vector{MOPSolution}, Vector{BOPSolution}}, ideal_point::Vector{T}) where {T<:Number}
     non_dom_sols[compute_closest_point_to_the_ideal_point(wrap_sols_into_array(non_dom_sols), ideal_point, true)]
 end
 
@@ -575,7 +575,7 @@ end
 
  Returns the closest point in the nondominated frontier `non_dom_sols` from its Ideal Point.
 """
-function compute_closest_point_to_the_ideal_point{T<:Number}(non_dom_sols::Array{T, 2})
+function compute_closest_point_to_the_ideal_point(non_dom_sols::Array{T, 2}) where {T<:Number}
     compute_closest_point_to_the_ideal_point(non_dom_sols, compute_ideal_point(non_dom_sols))
 end
 
@@ -597,7 +597,7 @@ end
     
  Returns the `Nadir Point` of the nondominated frontier `non_dom_sols`.
 """
-function compute_nadir_point{T<:Number}(non_dom_sols::Array{T, 2})
+function compute_nadir_point(non_dom_sols::Array{T, 2}) where {T<:Number}
     [ maximum(non_dom_sols[:, i]) for i in 1:size(non_dom_sols)[2] ]
 end
 
@@ -620,7 +620,7 @@ end
 
  Returns the farthest point in the nondominated frontier `non_dom_sols` from its Nadir Point `nadir_point`.
 """
-function compute_farthest_point_to_the_nadir_point{T<:Number}(non_dom_sols::Array{T, 2}, nadir_point::Vector{T}, return_pos::Bool=false)
+function compute_farthest_point_to_the_nadir_point(non_dom_sols::Array{T, 2}, nadir_point::Vector{T}, return_pos::Bool=false) where {T<:Number}
     best_pt_dist = -Inf
     best_pt = Float64[]
     best_pt_pos = 0
@@ -648,7 +648,7 @@ end
 
  Returns the farthest point in the nondominated frontier `non_dom_sols` from its Nadir Point `nadir_point`.
 """
-function compute_farthest_point_to_the_nadir_point{T<:Number}(non_dom_sols::Union{Vector{MOPSolution}, Vector{BOPSolution}}, nadir_point::Vector{T})
+function compute_farthest_point_to_the_nadir_point(non_dom_sols::Union{Vector{MOPSolution}, Vector{BOPSolution}}, nadir_point::Vector{T}) where {T<:Number}
     non_dom_sols[compute_farthest_point_to_the_nadir_point(wrap_sols_into_array(non_dom_sols), nadir_point, true)]
 end
 
@@ -657,7 +657,7 @@ end
     
  Returns the farthest point in the nondominated frontier `non_dom_sols` from its Nadir Point.
 """
-function compute_farthest_point_to_the_nadir_point{T<:Number}(non_dom_sols::Array{T, 2})
+function compute_farthest_point_to_the_nadir_point(non_dom_sols::Array{T, 2}) where {T<:Number}
     compute_farthest_point_to_the_nadir_point(non_dom_sols, compute_nadir_point(non_dom_sols))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,60 @@
+using Modof
+using Test
+using JuMP
+
+@testset "Modof smoke tests" begin
+    instance = BOBPInstance(false)
+    instance.c1 = [1.0, 2.0]
+    instance.c2 = [2.0, 1.0]
+    instance.A = [1.0 1.0]
+    instance.cons_lb = [-Inf]
+    instance.cons_ub = [1.0]
+
+    solution = BOPSolution(vars=[1.0, 0.0])
+    compute_objective_function_value!(solution, instance)
+
+    @test solution.obj_val1 == 1.0
+    @test solution.obj_val2 == 2.0
+    @test check_feasibility(solution, instance)
+    @test select_and_sort_non_dom_sols([1.0 2.0; 2.0 1.0; 3.0 3.0]) == [1.0 2.0; 2.0 1.0]
+end
+
+@testset "JuMP bridge" begin
+    model = ModoModel()
+    @variable(model, x[1:2], Bin)
+    @constraint(model, 2x[1] + x[2] <= 2)
+
+    objective!(model, 1, :Max, x[1] + 3x[2])
+    objective!(model, 2, :Min, 4x[1] + x[2])
+
+    instance, sense = read_an_instance_from_a_jump_model(model)
+
+    @test sense == [:Max, :Min]
+    @test instance isa BOBPInstance
+    @test instance.c1 == [-1.0, -3.0]
+    @test instance.c2 == [4.0, 1.0]
+    @test Matrix(instance.A) == [-2.0 -1.0]
+    @test instance.cons_lb == [-2.0]
+    @test instance.cons_ub == [Inf]
+
+    @test !any(name -> occursin("math" * "progbase", lowercase(String(name))), names(Modof; all=true))
+end
+
+@testset "LP file bridge" begin
+    model = ModoModel()
+    @variable(model, 0 <= x <= 1)
+    @variable(model, 0 <= y <= 1)
+    @constraint(model, x + y <= 1)
+    objective!(model, 1, :Min, x + 2y)
+
+    filename = tempname() * ".lp"
+    try
+        JuMP.write_to_file(model, filename)
+        instance, sense = read_an_instance_from_a_lp_or_a_mps_file(filename)
+        @test sense == [:Min]
+        @test instance isa MOLPInstance
+        @test instance.c == [1.0 2.0]
+    finally
+        isfile(filename) && rm(filename)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,4 +57,26 @@ end
     finally
         isfile(filename) && rm(filename)
     end
+
+    filename = tempname() * ".lp"
+    try
+        write(filename, """
+        Minimize
+         obj: x + 2 y
+        Subject To
+         cap: x + y <= 1
+         obj_2: 3 x + y = 0
+        Binaries
+         x y
+        End
+        """)
+        instance, sense = read_an_instance_from_a_lp_or_a_mps_file(filename, [:Min])
+        @test sense == [:Min, :Min]
+        @test instance isa BOBPInstance
+        @test instance.c1 == [1.0, 2.0]
+        @test instance.c2 == [3.0, 1.0]
+        @test any(i -> Matrix(instance.A)[i, :] == [-1.0, -1.0], axes(instance.A, 1))
+    finally
+        isfile(filename) && rm(filename)
+    end
 end


### PR DESCRIPTION
## Summary

This PR updates Modof.jl from the Julia 0.6-era package stack to a modern Julia package using JuMP, MathOptInterface, and GLPK.

The main motivation is to make the package build and load on current Julia versions without relying on obsolete MathProgBase / GLPKMathProgInterface dependencies.

## Changes

- Add modern `Project.toml` and `Manifest.toml`.
- Remove old `REQUIRE` metadata.
- Replace the MathProgBase-based model extraction path with a JuMP/MOI implementation.
- Update `ModoModel()` to use `GLPK.Optimizer`.
- Keep the modern public interface:
  - `ModoModel`
  - `objective!`
  - `read_an_instance_from_a_jump_model`
  - `read_an_instance_from_a_lp_or_a_mps_file`
- Remove deprecated MathProgBase-named APIs.
- Update Julia 0.6 syntax and removed Base APIs for Julia 1.x compatibility.
- Update README/docs installation instructions for Julia 1.10+.
- Add smoke tests covering core instance utilities, JuMP model conversion, and LP file import.

## Validation

Tested with Julia 1.12.5:

```julia
using Pkg
Pkg.resolve()
Pkg.build()
Pkg.test()
```